### PR TITLE
NOAA_NGDC_ETOPO1: Remove keywords used only once

### DIFF
--- a/catalog/NOAA/NGDC/NOAA_NGDC_ETOPO1.jsonnet
+++ b/catalog/NOAA/NGDC/NOAA_NGDC_ETOPO1.jsonnet
@@ -42,14 +42,13 @@ local self_url = catalog_subdir_url + base_filename;
     },
   ],
   keywords: [
-    'bathymetry',
+    // TODO(schwehr): Include bathymetry when it is used more than once.
+    // 'bathymetry',
     'bedrock',
     'dem',
     'elevation',
-    'etopo1',
     'geophysical',
     'ice',
-    'ngdc',
     'noaa',
     'topography',
   ],


### PR DESCRIPTION
- bathymetry will likely be used by more things in the future
- NGDC has been been reorganized into a new NOAA group
- etopo1 is never going to have another use of the tag