### PR TITLE
BUILD: Disable ee_stac_check_test

### DIFF
--- a/checker/BUILD
+++ b/checker/BUILD
@@ -23,16 +23,17 @@ py_library(
     ],
 )
 
-py_test(
-    name = "ee_stac_check_test",
-    srcs = ["ee_stac_check_test.py"],
-    deps = [
-        ":ee_stac_check_lib",
-        ":stac",
-        "//checker/node",
-        "//checker/tree",
-    ],
-)
+# This test does not work well in a github action.
+# py_test(
+#     name = "ee_stac_check_test",
+#     srcs = ["ee_stac_check_test.py"],
+#     deps = [
+#         ":ee_stac_check_lib",
+#         ":stac",
+#         "//checker/node",
+#         "//checker/tree",
+#     ],
+# )
 
 py_library(
     name = "stac",


### PR DESCRIPTION
Any test failure stops the process before the checker happens.  This test is what we use inside of google3 to run the checker, so any trouble that the checker finds will cause the process to stop.  The test failure stderr details do not appear in the GitHub check console.