### PR TITLE
update zenodo DOI

### DIFF
--- a/catalog/RUB/RUB_RUBCLIM_LCZ_global_lcz_map_v1.jsonnet
+++ b/catalog/RUB/RUB_RUBCLIM_LCZ_global_lcz_map_v1.jsonnet
@@ -323,7 +323,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
       },
     ],
   },
-  'sci:doi': '10.5281/zenodo.6364594',
+  'sci:doi': '10.5281/zenodo.6364593',
   'gee:extra_dois': [
     'https://doi.org/10.5194/essd-14-3835-2022',
   ],

--- a/catalog/RUB/RUB_RUBCLIM_LCZ_global_lcz_map_v1.jsonnet
+++ b/catalog/RUB/RUB_RUBCLIM_LCZ_global_lcz_map_v1.jsonnet
@@ -54,7 +54,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
     * [Global map of LCZs](https://doi.org/10.5194/essd-14-3835-2022)
 
-    * [Global map of LCZs - dataset](https://doi.org/10.5281/zenodo.6364594)
+    * [Global map of LCZs - dataset](https://doi.org/10.5281/zenodo.6364593)
 
     * [LCZ Gaussian filtering](https://doi.org/10.1038/s41597-020-00605-z)
   |||,
@@ -66,7 +66,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     },
     {
       rel: ee_const.rel.cite_as,
-      href: 'https://doi.org/10.5281/zenodo.6364594',
+      href: 'https://doi.org/10.5281/zenodo.6364593',
     },
   ],
   keywords: [


### PR DESCRIPTION
Hi there,

I would like to update the Zenodo DOI in the catalogue.
Previously I used a version specific DOI, yet I'd like to use the DOI that represents all versions, and will always resolve to the latest one. 

Hence this small change.