### PR TITLE
stac.examples_root: Check first for a local examples directory to support bazel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Test Checker
         run: bazel test --test_output=errors //...
       - name: Checker
-        run: bazel run //checker:ee_stac_check
+        run: bazel-bin/checker/ee_stac_check

--- a/checker/stac.py
+++ b/checker/stac.py
@@ -49,6 +49,11 @@ def stac_root() -> pathlib.Path:
 
 
 def examples_root() -> pathlib.Path:
+  # First try for a local path for bazel.
+  path = pathlib.Path('examples')
+  if path.is_dir(): return path
+
+  # blaze has Fileset support
   return data_root() / 'examples/javascript_examples'
 
 


### PR DESCRIPTION
Also: ci.yml: Directly call `ee_stac_check` to be able to find the examples directory