### PR TITLE
Updating OpenET start year to 2013

### DIFF
--- a/catalog/OpenET/OpenET_DISALEXI_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_DISALEXI_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -54,7 +54,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_EEMETRIC_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_EEMETRIC_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -96,7 +96,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -56,7 +56,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126.0, 25.0, -66.0, 50.0, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126.0, 25.0, -66.0, 50.0, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -83,7 +83,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_PTJPL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_PTJPL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -62,7 +62,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -83,7 +83,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_SSEBOP_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_SSEBOP_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -68,7 +68,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2016-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2013-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {


### PR DESCRIPTION
The monthly assets for years 2013-2015 were added to the collections, so updating the start year to reflect this.