### PR TITLE
Update broken Copernicus CDS and ADS URLs

### DIFF
--- a/catalog/ECMWF/ECMWF_CAMS_NRT.jsonnet
+++ b/catalog/ECMWF/ECMWF_CAMS_NRT.jsonnet
@@ -57,7 +57,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   providers: [
     ee.producer_provider(
       'European Centre for Medium-Range Weather Forecasts (ECMWF)',
-      'https://ads.atmosphere.copernicus.eu/cdsapp#!/dataset/cams-global-atmospheric-composition-forecasts'),
+      'https://ads.atmosphere.copernicus.eu/datasets/cams-global-atmospheric-composition-forecasts'),
     ee.host_provider(self_ee_catalog_url),
   ],
   extent: ee.extent_global('2016-06-22T12:00:00Z', null),

--- a/catalog/ECMWF/ECMWF_CAMS_NRT.jsonnet
+++ b/catalog/ECMWF/ECMWF_CAMS_NRT.jsonnet
@@ -41,7 +41,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   links: ee.standardLinks(subdir, id) + [
     {
       rel: ee_const.rel.license,
-      href: 'https://ads.atmosphere.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf',
+      href: 'https://object-store.os-api.cci2.ecmwf.int/cci2-prod-catalogue/licences/licence-to-use-copernicus-products/licence-to-use-copernicus-products_b4b9451f54cffa16ecef5c912c9cebd6979925a956e3fa677976e0cf198c2c18.pdf',
       type: ee_const.media_type.pdf,
     },
   ],
@@ -297,7 +297,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     programme, i.e., Sentinel mission data and Copernicus service information.
 
     See the
-    [full COPERNICUS data license](https://ads.atmosphere.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf).
+    [full COPERNICUS data license](https://object-store.os-api.cci2.ecmwf.int/cci2-prod-catalogue/licences/licence-to-use-copernicus-products/licence-to-use-copernicus-products_b4b9451f54cffa16ecef5c912c9cebd6979925a956e3fa677976e0cf198c2c18.pdf).
 
     The license clauses with attribution requirements are shown below:
 

--- a/catalog/ECMWF/ECMWF_ERA5_DAILY.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_DAILY.jsonnet
@@ -59,7 +59,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     'wind',
   ],
   providers: [
-    ee.producer_provider('ECMWF / Copernicus Climate Change Service', 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels'),
+    ee.producer_provider('ECMWF / Copernicus Climate Change Service', 'https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels'),
     ee.host_provider(self_ee_catalog_url),
   ],
   extent: ee.extent_global('1979-01-02T00:00:00Z', null),
@@ -314,7 +314,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   },
   'sci:citation': |||
     Copernicus Climate Change Service (C3S) (2017): ERA5: Fifth generation of ECMWF atmospheric reanalyses of the global climate.
-    Copernicus Climate Change Service Climate Data Store (CDS), (date of access), [https://cds.climate.copernicus.eu/cdsapp#!/home](https://cds.climate.copernicus.eu/cdsapp#!/home)
+    Copernicus Climate Change Service Climate Data Store (CDS), (date of access), [https://cds.climate.copernicus.eu](https://cds.climate.copernicus.eu)
   |||,
   'gee:interval': {
     type: 'cadence',

--- a/catalog/ECMWF/ECMWF_ERA5_LAND_DAILY_AGGR.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_LAND_DAILY_AGGR.jsonnet
@@ -50,7 +50,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   providers: [
     ee.producer_provider(
       'Daily Aggregates: Google and Copernicus Climate Data Store',
-      'https://cds.climate.copernicus.eu/cdsapp'
+      'https://cds.climate.copernicus.eu'
     ),
     ee.host_provider(self_ee_catalog_url),
   ],

--- a/catalog/ECMWF/ECMWF_ERA5_LAND_HOURLY.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_LAND_HOURLY.jsonnet
@@ -35,7 +35,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
     ERA5-Land data is available from 1950 to three months from real-time. More
     information can be found at the
-    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land?tab=overview).
+    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=overview).
   |||,
   license: license.id,
   links: ee.standardLinks(subdir, id),
@@ -43,7 +43,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   providers: [
     ee.producer_provider(
       'Copernicus Climate Data Store',
-      'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land?tab=overview'
+      'https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land?tab=overview'
     ),
     ee.host_provider(self_ee_catalog_url),
   ],

--- a/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY.jsonnet
@@ -35,7 +35,7 @@ local license = spdx.proprietary;
 
     ERA5-Land data is available from 1950 to three months from real-time. More
     information can be found at the
-    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means?tab=overview).
+    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means?tab=overview).
   |||,
   license: license.id,
   links: ee.standardLinks(subdir, id) + version_config.version_links,
@@ -43,7 +43,7 @@ local license = spdx.proprietary;
   providers: [
     ee.producer_provider(
       'Copernicus Climate Data Store',
-      'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-land-monthly-means?tab=overview'
+      'https://cds.climate.copernicus.eu/datasets/reanalysis-era5-land-monthly-means?tab=overview'
     ),
     ee.host_provider(version_config.ee_catalog_url),
   ],

--- a/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY_AGGR.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY_AGGR.jsonnet
@@ -50,7 +50,7 @@ local license = spdx.proprietary;
   providers: [
     ee.producer_provider(
       'Monthly Aggregates: Google and Copernicus Climate Data Store',
-      'https://cds.climate.copernicus.eu/cdsapp'
+      'https://cds.climate.copernicus.eu'
     ),
     ee.host_provider(version_config.ee_catalog_url),
   ],

--- a/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY_BY_HOUR.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_LAND_MONTHLY_BY_HOUR.jsonnet
@@ -68,7 +68,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     'wind',
   ],
   providers: [
-    ee.producer_provider('Climate Data Store', 'https://cds.climate.copernicus.eu/cdsapp'),
+    ee.producer_provider('Climate Data Store', 'https://cds.climate.copernicus.eu'),
     ee.host_provider(self_ee_catalog_url),
   ],
   extent: ee.extent_global('1950-01-01T01:00:00Z', null),

--- a/catalog/ECMWF/ECMWF_ERA5_MONTHLY.jsonnet
+++ b/catalog/ECMWF/ECMWF_ERA5_MONTHLY.jsonnet
@@ -39,7 +39,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
     ERA5 data is available from 1940 to three months from real-time, the version in the EE Data Catalog is available from 1979. More information
     and more ERA5 atmospheric parameters can be found at the
-    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means?tab=overview).
+    [Copernicus Climate Data Store](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means?tab=overview).
 
     Provider's Note: Monthly aggregates have been calculated based on the ERA5 hourly values
     of each parameter.
@@ -60,7 +60,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     'wind',
   ],
   providers: [
-    ee.producer_provider('ECMWF / Copernicus Climate Change Service', 'https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels-monthly-means?tab=overview'),
+    ee.producer_provider('ECMWF / Copernicus Climate Change Service', 'https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means?tab=overview'),
     ee.host_provider(self_ee_catalog_url),
   ],
   extent: ee.extent_global('1979-01-01T00:00:00Z', null),
@@ -310,7 +310,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   },
   'sci:citation': |||
     Copernicus Climate Change Service (C3S) (2017): ERA5: Fifth generation of ECMWF atmospheric reanalyses of the global climate.
-    Copernicus Climate Change Service Climate Data Store (CDS), (date of access), [https://cds.climate.copernicus.eu/cdsapp#!/home](https://cds.climate.copernicus.eu/cdsapp#!/home)
+    Copernicus Climate Change Service Climate Data Store (CDS), (date of access), [https://cds.climate.copernicus.eu](https://cds.climate.copernicus.eu)
   |||,
   'gee:interval': {
     type: 'cadence',


### PR DESCRIPTION
CDS and ADS [recently migrated](https://confluence.ecmwf.int/display/CKB/Please+read%3A+CDS+and+ADS+migrating+to+new+infrastructure%3A+Common+Data+Store+%28CDS%29+Engine), breaking all the old URLs. This replaces them with the equivalent updated URLs. 

I also replaced a couple broken links to a Copernicus license file. I checked Wayback Machine and the [updated license](https://object-store.os-api.cci2.ecmwf.int/cci2-prod-catalogue/licences/licence-to-use-copernicus-products/licence-to-use-copernicus-products_b4b9451f54cffa16ecef5c912c9cebd6979925a956e3fa677976e0cf198c2c18.pdf) matches the [old license](http://web.archive.org/web/20240602092915/https://ads.atmosphere.copernicus.eu/api/v2/terms/static/licence-to-use-copernicus-products.pdf), but I'm not sure how persistent the new URL is. Another alternative would be https://apps.ecmwf.int/datasets/licences/copernicus/ which includes the same license text.

