### PR TITLE
OpenET - Update start date to 1999-10-01

### DIFF
--- a/catalog/OpenET/OpenET_DISALEXI_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_DISALEXI_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -53,7 +53,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '2001-01-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_EEMETRIC_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_EEMETRIC_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -95,7 +95,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_ENSEMBLE_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -55,7 +55,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126.0, 25.0, -66.0, 50.0, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126.0, 25.0, -66.0, 50.0, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_GEESEBAL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -82,7 +82,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_PTJPL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_PTJPL_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -61,7 +61,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_SIMS_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -82,7 +82,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {

--- a/catalog/OpenET/OpenET_SSEBOP_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
+++ b/catalog/OpenET/OpenET_SSEBOP_CONUS_GRIDMET_MONTHLY_v2_0.jsonnet
@@ -67,7 +67,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ee.producer_provider('OpenET, Inc.', 'https://openetdata.org/'),
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent(-126, 25, -66, 50, '2008-01-01T00:00:00Z', null),
+  extent: ee.extent(-126, 25, -66, 50, '1999-10-01T00:00:00Z', null),
   summaries: {
     'gee:schema': [
       {


### PR DESCRIPTION
Setting start date to 1999-10-01 for all models except DisALEXI, which cannot be run before 2001.