### PR TITLE
MethaneSAT: add comment to examples and update owners to use request form

### DIFF
--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var dataset = ee.ImageCollection("projects/edf-methanesat-ee/assets/public-preview/L3concentration")
   .filterDate('2024-06-01', '2025-01-31');
 

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration_preview.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration_preview.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var methaneSATArea = ee.ImageCollection("projects/edf-methanesat-ee/assets/public-preview/L3concentration")
   .filterDate('2024-06-01', '2025-01-31');
 

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var dataset = ee.ImageCollection("projects/edf-methanesat-ee/assets/public-preview/L4area")
   .filterDate('2024-06-01', '2025-01-31');
 

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area_preview.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area_preview.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var methaneSATArea = ee.ImageCollection("projects/edf-methanesat-ee/assets/public-preview/L4area")
   .filterDate('2024-06-01', '2025-01-31');
 

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var dataset = ee.FeatureCollection("projects/edf-methanesat-ee/assets/public-preview/L4point");
 
 // Add a `style` property with `pointSize` dependent on flux value.

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point_FeatureView.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point_FeatureView.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var fvLayer = ui.Map.FeatureViewLayer('projects/edf-methanesat-ee/assets/public-preview/L4point_FeatureView');
 
 var visParams = {

--- a/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point_preview.js
+++ b/examples/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4point_preview.js
@@ -1,3 +1,4 @@
+// Request access to this data by filling out the form at: https://forms.gle/jqw4Mvr63dsV1fUF8
 var dataset = ee.FeatureCollection("projects/edf-methanesat-ee/assets/public-preview/L4point");
 
 // Add a `style` property with `pointSize` dependent on flux value.

--- a/owners/edf-methanesat-ee.jsonnet
+++ b/owners/edf-methanesat-ee.jsonnet
@@ -4,7 +4,7 @@
   "description": "Launched into orbit on March 4th, 2024, MethaneSAT is the first satellite developed and funded by an environmental nonprofit organization. It is the only methane-detecting satellite that sees the whole picture, measuring methane emissions from millions of small sources around the world that are a huge part of the problem.
 It has one purpose — to speed up reductions in methane emissions as quickly as possible, so we can slow down global warming. During our Public Preview, MethaneSAT data are freely available via request so that companies, governments and advocates can speed up emissions cuts, track progress and hold polluters truly accountable. MethaneSAT LLC is a wholly owned subsidiary of Environmental Defense Fund.
 
-You will need to apply for use of this data via [this form](https://www.methanesat.org/contact/).
+You will need to apply for use of this data via [this form](https://forms.gle/jqw4Mvr63dsV1fUF8).
 See the dataset Terms of Use for more information.
 ",
   "homeBucket": "projects/edf-methanesat-ee",


### PR DESCRIPTION
add a comment to the examples telling the user they need to fill out the form.  See screenshot:

![image](https://github.com/user-attachments/assets/aea9b2e8-1c9b-447f-a3fc-d4d8658e169c)

Also updated the form link on the owners page to go to the data request form instead of the contact form.
