### PR TITLE
Small updates for MethaneSAT in EE Catalog

### DIFF
--- a/catalog/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration.jsonnet
+++ b/catalog/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L3concentration.jsonnet
@@ -54,7 +54,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     // This is always the last entry.
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent_global('2006-01-24T00:00:00Z', '2025-01-17T00:00:00Z'),
+  extent: ee.extent_global('2006-01-24T00:00:00Z', null),
   summaries: {
     'gsd': [10.2],
     'eo:bands': [

--- a/catalog/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area.jsonnet
+++ b/catalog/edf-methanesat-ee/projects_edf-methanesat-ee_assets_public-preview_L4area.jsonnet
@@ -65,7 +65,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     // This is always the last entry.
     ee.host_provider(self_ee_catalog_url),
   ],
-  extent: ee.extent_global('2006-01-24T00:00:00Z', '2025-01-17T00:00:00Z'),
+  extent: ee.extent_global('2006-01-24T00:00:00Z', null),
   summaries: {
     'eo:bands': [
       {

--- a/owners/edf-methanesat-ee.jsonnet
+++ b/owners/edf-methanesat-ee.jsonnet
@@ -2,9 +2,10 @@
   "contactDisplay": "EDF-MethaneSAT",
   "contactLink": "https://www.methanesat.org/contact",
   "description": "Launched into orbit on March 4th, 2024, MethaneSAT is the first satellite developed and funded by an environmental nonprofit organization. It is the only methane-detecting satellite that sees the whole picture, measuring methane emissions from millions of small sources around the world that are a huge part of the problem.
-It has one purpose — to speed up reductions in methane emissions as quickly as possible, so we can slow down global warming. During our Public Preview, MethaneSAT data are freely available via request so that companies, governments and advocates can speed up emissions cuts, track progress and hold polluters truly accountable. MethaneSAT LLC is a wholly owned subsidiary of Environmental Defense Fund.
+It has one purpose- to speed up reductions in methane emissions as quickly as possible, so we can slow down global warming. During our Public Preview, MethaneSAT data are freely available via request so that companies, governments, and advocates can speed up emissions cuts, track progress, and hold polluters truly accountable. MethaneSAT LLC is a wholly owned subsidiary of Environmental Defense Fund.
+Users who are interested in downloading the data directly rather than exploring through Earth Engine may do so through Google Cloud Platform, where we have the same underlying datasets available.
 
-You will need to apply for use of this data via [this form](https://forms.gle/jqw4Mvr63dsV1fUF8).
+You will need to apply for use of this data to access on both Google Earth Engine and Google Cloud Platform via [this form](https://forms.gle/jqw4Mvr63dsV1fUF8).
 See the dataset Terms of Use for more information.
 ",
   "homeBucket": "projects/edf-methanesat-ee",


### PR DESCRIPTION
* Text updates in the description
* For our raster data sets, setting the Dataset Availability end dates to null so that EE will generate these automatically going forward

Question for the reviewer: last time we chatted with Simon, it sounded like this change we're making with the end dates (setting the end date to null so that EE would determine the end date automatically instead) was only supported on raster data sets. We'd love to use this for our vector data sets as well. Just double checking that it's still not supported / if it might be supported in the future?