### PR TITLE
Update rules_jsonnet, rules_python, python toolchain

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,26 +1,17 @@
-bazel_dep(name = "rules_jsonnet", version = "0.6.0")
-bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "rules_python", version = "0.35.0")
-
-# Temporary workaround
-# TODO(simonf): remove when https://github.com/google/jsonnet/pull/1189 is pushed
-# to rules_jsonnet
-git_override(
-	module_name = "jsonnet",
-	commit = "4487bfb8ba7ed7a3d91d79d4a1aa2205e7839558",
-	remote = "https://github.com/google/jsonnet.git",
-)
+bazel_dep(name = "rules_jsonnet", version = "0.7.2")
+bazel_dep(name = "bazel_skylib", version = "1.8.0")
+bazel_dep(name = "rules_python", version = "1.5.1")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
-    python_version = "3.10"
+    python_version = "3.11"
 )
-use_repo(python, "python_3_10")
+use_repo(python)
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
 pip.parse(
     hub_name = "pip",
-    python_version = "3.10",
+    python_version = "3.11",
     requirements_lock = "//:requirements.txt",
 )
 use_repo(pip, "pip")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,9 @@ bazel_dep(name = "rules_jsonnet", version = "0.7.2")
 bazel_dep(name = "bazel_skylib", version = "1.8.0")
 bazel_dep(name = "rules_python", version = "1.5.1")
 
+jsonnet = use_extension("@rules_jsonnet//jsonnet:extensions.bzl", "jsonnet")
+jsonnet.compiler(name = "cpp")
+
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
 python.toolchain(
     python_version = "3.11"

--- a/checker/BUILD
+++ b/checker/BUILD
@@ -1,5 +1,7 @@
 # Earth Engine Public Data Catalog STAC checker.
 load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
+
 package(default_visibility = ["//visibility:public"])
 
 py_binary(

--- a/checker/node/BUILD
+++ b/checker/node/BUILD
@@ -1,5 +1,6 @@
 # Checks that operate on only a single STAC node at a time.
 load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "node",

--- a/checker/tree/BUILD
+++ b/checker/tree/BUILD
@@ -1,4 +1,5 @@
 load("@pip//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 # Checks working on two or more STAC nodes at a time.
 


### PR DESCRIPTION
rules_jsonnet 0.7.2 brings in jsonnet 0.21.0, so the git repo override can be removed.

rules_python bumped to 1.5.1. Also BUILD files updated to explicitly load python rules from rules_python, as newer Bazel versions don't provide py_* rules as builtins. See:
https://rules-python.readthedocs.io/en/latest/#migrating-from-the-bundled-rules

Python toolchain bumped to 3.11 because 3.10 was hitting some problem with setuptools (I gave up on diagnosing this).