### PR TITLE
Update MODIS/061/MOD16A2 date range to correctly reflect description

### DIFF
--- a/catalog/MODIS/MODIS_061_MOD16A2.jsonnet
+++ b/catalog/MODIS/MODIS_061_MOD16A2.jsonnet
@@ -88,7 +88,7 @@ local template = import 'templates/MODIS_006_MOD16A2.libsonnet';
   'gee:provider_ids': [
     'C1000000524-LPDAAC_ECS',
   ],
-  extent: ee.extent_global('2001-01-01T00:00:00Z', null),
+  extent: ee.extent_global('2021-01-01T00:00:00Z', null),
   summaries: template.summaries {
     platform: [
       'Terra',


### PR DESCRIPTION
Updates the date coverage from 2000 onwards, to 2021 onwards, correctly reflecting the description where users should merge it with the gapfilled dataset.

This can be trivially verified with [this script](https://code.earthengine.google.com/d710d82be327d5d82e04a35908769aa3)