### PR TITLE
Add v1.3 of drivers of forest loss data to the land and carbon publisher catalog

### DIFF
--- a/catalog/landandcarbon/catalog.jsonnet
+++ b/catalog/landandcarbon/catalog.jsonnet
@@ -25,6 +25,7 @@ local self_url = base_url + base_filename;
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2001_2022', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_1_2001_2023', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2_2001_2024', base_url),
+    ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025', base_url),
   ]
 } 
 

--- a/catalog/landandcarbon/catalog.jsonnet
+++ b/catalog/landandcarbon/catalog.jsonnet
@@ -25,7 +25,7 @@ local self_url = base_url + base_filename;
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2001_2022', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_1_2001_2023', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2_2001_2024', base_url),
-    ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025', base_url),
+    //ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025', base_url),
   ]
 } 
 

--- a/catalog/landandcarbon/catalog.jsonnet
+++ b/catalog/landandcarbon/catalog.jsonnet
@@ -25,7 +25,7 @@ local self_url = base_url + base_filename;
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2001_2022', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_1_2001_2023', base_url),
     ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_2_2001_2024', base_url),
-    //ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025', base_url),
+    ee.link.child_collection('projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025', base_url),
   ]
 } 
 

--- a/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
+++ b/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
@@ -190,6 +190,9 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
   'gee:terms_of_use': ee.gee_terms_of_use(license),
 
+    // TODO(google): Remove gee:status when the dataset is ready.
+  'gee:status': 'incomplete'
+
   'gee:type': ee_const.gee_type.image,
   license: license.id,
   links: ee.standardLinks(subdir, id),

--- a/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
+++ b/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
@@ -1,11 +1,11 @@
-local id = 'projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_2_2001_2024';
+local id = 'projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_3_2001_2025';
 local subdir = 'landandcarbon';
 
 local ee_const = import 'earthengine_const.libsonnet';
 local ee = import 'earthengine.libsonnet';
 local spdx = import 'spdx.libsonnet';
 local units = import 'units.libsonnet';
-local version = '1.2';
+local version = '1.3';
 
 local license = spdx.cc_by_4_0;
 
@@ -14,11 +14,11 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
 {
   id: id,
-  title: 'WRI/Google DeepMind Global Drivers of Forest Loss 2001-2024 v1.2',
+  title: 'WRI/Google DeepMind Global Drivers of Forest Loss 2001-2025 v1.3',
   version: version,
 
   description: |||
-    This dataset maps the dominant driver of tree cover loss from 2001-2024 globally at 1 km resolution. 
+    This dataset maps the dominant driver of tree cover loss from 2001-2025 globally at 1 km resolution. 
     Produced by the World Resources Institute (WRI) and Google DeepMind, the data were developed using 
     a global neural network model (ResNet) trained on a set of samples collected through visual 
     interpretation of very high-resolution satellite imagery. The model used satellite imagery 
@@ -70,14 +70,14 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     multiple drivers if they occur in the same cell at smaller scales, nor does it detail the sequence of 
     drivers if multiple occurred at different times within the period. Additionally, these data are limited 
     in scope to attributing drivers to tree cover loss as mapped by the 
-    [Global Forest Change v1.12](https://www.science.org/doi/10.1126/science.1244693) tree cover loss product, 
+    [Global Forest Change v1.13](https://www.science.org/doi/10.1126/science.1244693) tree cover loss product, 
     and therefore the detection of loss is subject to the accuracy of that product. 
     
     **For a full description of the methods, technical specifications, definitions, accuracy, and 
     limitations, please see the publication**: 
     [https://doi.org/10.1088/1748-9326/add606](https://doi.org/10.1088/1748-9326/add606). 
-    The data is also available for download on [Zenodo](https://zenodo.org/records/15366671) and 
-    the [WRI Data Explorer](https://datasets.wri.org/datasets/dominant-drivers-of-tree-cover-loss-at-1km-v1-2).  
+    The data is also available for download on [Zenodo](https://zenodo.org/records/19485190) and 
+    the [WRI Data Explorer](https://datasets.wri.org/datasets/dominant-drivers-of-tree-cover-loss-at-1km).  
   |||, 
 
 
@@ -93,12 +93,12 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     ],
 
   providers: [
-    ee.producer_provider('World Resources Institute', 'https://zenodo.org/records/15366671'),
+    ee.producer_provider('World Resources Institute', 'https://zenodo.org/records/19485190'),
     ee.producer_provider('Google DeepMind', 'https://deepmind.google/'),
     ee.host_provider(self_ee_catalog_url),
   ],
 
-  extent: ee.extent_global('2001-01-01T00:00:00Z', '2025-01-01T00:00:00Z'),
+  extent: ee.extent_global('2001-01-01T00:00:00Z', '2026-01-01T00:00:00Z'),
 
   summaries: {
     gsd: [1111.95],

--- a/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
+++ b/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
@@ -191,7 +191,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   'gee:terms_of_use': ee.gee_terms_of_use(license),
 
     // TODO(google): Remove gee:status when the dataset is ready.
-  'gee:status': 'incomplete'
+  'gee:status': 'incomplete',
 
   'gee:type': ee_const.gee_type.image,
   license: license.id,

--- a/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
+++ b/catalog/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.jsonnet
@@ -191,7 +191,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   'gee:terms_of_use': ee.gee_terms_of_use(license),
 
     // TODO(google): Remove gee:status when the dataset is ready.
-  'gee:status': 'incomplete',
+  'gee:status': 'beta',
 
   'gee:type': ee_const.gee_type.image,
   license: license.id,

--- a/examples/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.js
+++ b/examples/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025.js
@@ -1,0 +1,23 @@
+Map.setCenter(-9.22,20.65,3)
+
+var drivers = ee.Image('projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_3_2001_2025');
+
+var drivers_class = drivers.select(['classification']);
+
+var vis = {
+  "min":1, 
+  "max": 7,
+  "palette": ['E39D29','E58074','e9d700','51a44e','895128','a354a0','3a209a']
+};
+
+Map.addLayer(drivers_class, vis, 'Drivers of Forest Loss, 2001-2025');
+
+var permAg_prob = drivers.select(['probability_1']); //Select a probability band
+
+var probVis = {
+  min: 0,
+  max: 250,
+  palette: ['#440154','#481567','#482677','#453781','#3b528b','#2c728e','#21908d','#27ad81','#5ec962','#aadc32','#fde725']
+};
+
+Map.addLayer(permAg_prob, probVis, 'Probability band for permanent agriculture', false); 

--- a/examples/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025_preview.js
+++ b/examples/landandcarbon/projects_landandcarbon_assets_wri_gdm_drivers_forest_loss_1km_v1_3_2001_2025_preview.js
@@ -1,0 +1,40 @@
+var drivers = ee.Image('projects/landandcarbon/assets/wri_gdm_drivers_forest_loss_1km/v1_3_2001_2025');
+
+var drivers_class = drivers.select(['classification'])
+
+var vis = {
+  "min":1, 
+  "max": 7,
+  "palette": ['E39D29','E58074','e9d700','51a44e','895128','a354a0','3a209a']
+};
+
+Map.addLayer(drivers_class, vis, 'Drivers of Forest Loss, 2001-2025')
+
+var lon = -30
+var lat = 10
+
+Map.setCenter(lon, lat, 3);
+
+// Degrees in EPSG:4326
+var delta = 64;
+var pixels = 256;
+
+var areaOfInterest = ee.Geometry.Rectangle(
+  [lon - delta, lat - delta, lon + delta, lat + delta], null, false);
+  
+var parameters = {
+  dimensions: [pixels, pixels],
+  region: areaOfInterest,
+  crs: 'EPSG:3857',
+  format: 'png'
+};
+
+var backGround = ee.Image(1).visualize({palette: ['lightgray']})
+var waterLand = ee.Image('NOAA/NGDC/ETOPO1').select('bedrock').gt(0.0).clip(
+  ee.Geometry.BBox(-180, -55, 180, 75));
+var waterLandBackground =
+    waterLand.visualize({palette: ['white', 'lightgray']});
+    
+var imageWithBg = backGround.blend(waterLandBackground.blend(drivers_class.visualize(vis)));
+
+print(ui.Thumbnail({image: imageWithBg, params: parameters}));


### PR DESCRIPTION
Add v1.3 of the drivers of forest loss data to the land and carbon publisher catalog (note data is under embargo until April 29). Edited a link in the description for v1.2