### PR TITLE
Add 2026 JRC report citation for GFC2020 v3 and GFT2020 v1 + some typo corrections

### DIFF
--- a/catalog/JRC/JRC_GFC2020_V3.jsonnet
+++ b/catalog/JRC/JRC_GFC2020_V3.jsonnet
@@ -63,9 +63,9 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     agroforestry, and other land uses. The application of a series of complex Boolean decision
     rules excludes areas that are not forest according to the definition of the FAO-FRA and EUDR.
 
-    The global input layers, mapping approach, and accuracy of GFC 2020 version 3 will be
-    described in a separate technical report, expected to be released by March 2026. A technical
-    report ([Bourgoin et al 2024](https://op.europa.eu/en/publication-detail/-/publication/f9baaa45-e73f-11ee-9ea8-01aa75ed71a1/language-en)) describes the mapping approach for the first version; methodological
+    The global input layers, mapping approach, and accuracy of GFC 2020 version 3 are
+    described in a Science for Policy report released in May 2026 and available from the JRC Publications Repository: [Bourgoin et al. 2026](https://publications.jrc.ec.europa.eu/repository/handle/JRC146622). A technical
+    report ([Bourgoin et al. 2024](https://op.europa.eu/en/publication-detail/-/publication/f9baaa45-e73f-11ee-9ea8-01aa75ed71a1/language-en)) describes the mapping approach for the first version; methodological
     changes in version 2 and comparisons with other maps are described in [Bourgoin et al. (2025)](https://op.europa.eu/en/publication-detail/-/publication/e2c286ac-14e9-11f0-b1a3-01aa75ed71a1/language-en).
     [Colditz et al. (2025)](https://op.europa.eu/en/publication-detail/-/publication/e86f56dd-15b5-11f0-b1a3-01aa75ed71a1/language-en) describe the accuracy assessment protocol and results for GFC 2020 version 2.
     [Bourgoin et al. 2025](https://essd.copernicus.org/preprints/essd-2025-351/) present the mapping methodology and accuracy and compare the map to other
@@ -109,6 +109,17 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
         the EU Deforestation Regulation, Earth Syst. Sci. Data Discuss.
         [https://doi.org/10.5194/essd-2025-351](https://doi.org/10.5194/essd-2025-351),
         2025.
+      |||
+    },
+    {
+      citation: |||
+        Bourgoin, C., Verhegghen, A., Ameztoy, I., Beuchle, R., Carboni, S. et al.,
+        Maps of Global Forest Cover 2020 Version 3 and Global Forest Type 2020
+        Version 1 Supporting the EU Deforestation Regulation - Methodology,
+        Accuracy Assessment and Comparison, Publications Office of the European
+        Union, Luxembourg, 2026,
+        [https://data.europa.eu/doi/10.2760/9982436](https://data.europa.eu/doi/10.2760/9982436),
+        JRC146622.
       |||
     }
   ],

--- a/catalog/JRC/JRC_GFC2020_subtypes_V1.jsonnet
+++ b/catalog/JRC/JRC_GFC2020_subtypes_V1.jsonnet
@@ -56,7 +56,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
 
     The global map of forest types v1 combines available global datasets
     (wall-to-wall or global in their scope) that indicate or are proxies for the
-    four main forest types The main data layers that are used to delineate primary
+    four main forest types. The main data layers that are used to delineate primary
     forests in GFT 2020 are:
 
     1. The Forest Landscape Integrity Index in 2019
@@ -79,8 +79,9 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     1. global drivers of forest loss.
     1. Global natural forests 2020.
 
-    The global input layers and mapping approach of GFT 2020 version 1 will be
-    described in a separate technical report, expected to be released by March 2026.
+    The global input layers and mapping approach of GFT 2020 version 1 are
+    described in a separate technical report, expected to be released by March 2026 and available from
+    the JRC Publications Repository: [Bourgoin et al. 2026](https://publications.jrc.ec.europa.eu/repository/handle/JRC146622).
     A technical report [Bourgoin et al. 2025](https://op.europa.eu/en/publication-detail/-/publication/e2c286ac-14e9-11f0-b1a3-01aa75ed71a1/language-en)
     describes the mapping approach for the preliminary version (version 0) of GFT 2020.
 
@@ -116,6 +117,17 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
     {
       citation: |||
         Bourgoin, C., Verhegghen, A., Carboni, S., Degreve, L., Ameztoy Aramendi, I., Ceccherini, G., Colditz, R. and Achard, F., Global Forest Maps for the Year 2020 to Support the EU Regulation on Deforestation-free Supply Chains, Publications Office of the European Union, Luxembourg, 2025, [https://data.europa.eu/doi/10.2760/1975879](https://data.europa.eu/doi/10.2760/1975879), JRC141702.
+      |||
+    },
+    {
+      citation: |||
+        Bourgoin, C., Verhegghen, A., Ameztoy, I., Beuchle, R., Carboni, S. et al.,
+        Maps of Global Forest Cover 2020 Version 3 and Global Forest Type 2020
+        Version 1 Supporting the EU Deforestation Regulation - Methodology,
+        Accuracy Assessment and Comparison, Publications Office of the European
+        Union, Luxembourg, 2026,
+        [https://data.europa.eu/doi/10.2760/9982436](https://data.europa.eu/doi/10.2760/9982436),
+        JRC146622.
       |||
     }
   ],

--- a/examples/JRC/JRC_GFC2020_subtypes_V1.js
+++ b/examples/JRC/JRC_GFC2020_subtypes_V1.js
@@ -21,5 +21,5 @@ var PALETTE =
     var GFT2020 = ee.Image('JRC/GFC2020_subtypes/V1');
 Map.addLayer(
     GFT2020, {min: 0, max: 20, palette: PALETTE},
-    'EC JRC Global forest types 2020 – V0')
+    'EC JRC Global forest types 2020 – V1')
 Map.setOptions('SATELLITE')

--- a/examples/JRC/JRC_GFC2020_subtypes_V1_preview.js
+++ b/examples/JRC/JRC_GFC2020_subtypes_V1_preview.js
@@ -14,7 +14,7 @@ var imageWithBackground =
 
 Map.setCenter(0.0, 0.0, 2);
 
-Map.addLayer(image2020, {}, 'EC JRC Global forest types 2020 – V0');
+Map.addLayer(image2020, {}, 'EC JRC Global forest types 2020 – V1');
 
 var lon = -70;
 var lat = -10;


### PR DESCRIPTION
This PR adds the 2026 JRC technical report citation to the Earth Engine catalog
metadata for:

- JRC/GFC2020/V3
- JRC/GFC2020_subtypes/V1

The report documents the methodology, accuracy assessment, and comparison for
Global Forest Cover 2020 Version 3 and Global Forest Type 2020 Version 1.

Reference added:
Bourgoin, C., Verhegghen, A., Ameztoy, I., Beuchle, R., Carboni, S. et al.,
Maps of Global Forest Cover 2020 Version 3 and Global Forest Type 2020 Version 1
Supporting the EU Deforestation Regulation - Methodology, Accuracy Assessment and
Comparison, Publications Office of the European Union, Luxembourg, 2026,
https://data.europa.eu/doi/10.2760/9982436, JRC146622.

The description text was also updated to replace the previous “expected to be
released” wording now that the report is available.

- Fixes the GFT2020 example code snippet by changing the displayed layer label from V0 to V1.