### PR TITLE
correct GSD pixel size to 1km for MODIS MCD18A1

### DIFF
--- a/catalog/MODIS/templates/MODIS_061_MCD18A1.libsonnet
+++ b/catalog/MODIS/templates/MODIS_061_MCD18A1.libsonnet
@@ -20,7 +20,7 @@ local units = import 'units.libsonnet';
   |||,
   summaries: {
     gsd: [
-      500.0,
+      1000.0,
     ],
     instruments: [
       'MODIS',


### PR DESCRIPTION
This PR updates the Ground Sample Distance (gsd) in the MODIS_061_MCD18A1.libsonnet template from 500.0 to 1000.0.  The Earth Engine Data Catalog incorrectly lists the pixel size for the MCD18A1.061 and MCD18A1.062 (Surface Radiation) products as 500 meters. as per the official NASA LP DAAC documentation, this is a 1 km dataset.