### PR TITLE
Fix incorrect GSD for MODIS MCD18C2.062

### DIFF
--- a/catalog/MODIS/templates/MODIS_061_MCD18C2.libsonnet
+++ b/catalog/MODIS/templates/MODIS_061_MCD18C2.libsonnet
@@ -18,7 +18,7 @@
   |||,
   summaries: {
     gsd: [
-      500.0,
+      5566.0
     ],
     instruments: [
       'MODIS',


### PR DESCRIPTION
The MCD18C2 product is a Climate Modeling Grid (CMG) product with a spatial resolution of 0.05 degrees.
The dataset's description text already correctly states it is produced at "0.05 degree (5,600 meters at the equator) resolution", but the `gsd` array incorrectly listed 500m, causing the bands table on the catalog page to display the wrong resolution.
