### PR TITLE
Fix pixel size for WaPOR v3 L1 dekadal collections.

### DIFF
--- a/catalog/FAO/FAO_WAPOR_3_L1_AETI_D.jsonnet
+++ b/catalog/FAO/FAO_WAPOR_3_L1_AETI_D.jsonnet
@@ -49,7 +49,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   ],
   extent: ee.extent_global('2018-01-01T00:00:00Z', null),
   summaries: {
-    gsd: [248.2],
+    gsd: [326.13],
     'eo:bands': [
       {
         name: 'L1-AETI-D',

--- a/catalog/FAO/FAO_WAPOR_3_L1_E_D.jsonnet
+++ b/catalog/FAO/FAO_WAPOR_3_L1_E_D.jsonnet
@@ -48,7 +48,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   ],
   extent: ee.extent_global('2018-01-01T00:00:00Z', null),
   summaries: {
-    gsd: [248.2],
+    gsd: [326.13],
     'eo:bands': [
       {
         name: 'L1-E-D',

--- a/catalog/FAO/FAO_WAPOR_3_L1_I_D.jsonnet
+++ b/catalog/FAO/FAO_WAPOR_3_L1_I_D.jsonnet
@@ -51,7 +51,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   extent: ee.extent(-30.0044643, -40.0044644, 65.0044644, 40.0044643,
                     '2009-01-01T00:00:00Z', null),
   summaries: {
-    gsd: [248.2],
+    gsd: [326.13],
     'eo:bands': [
       {
         name: 'L1-I-D',

--- a/catalog/FAO/FAO_WAPOR_3_L1_T_D.jsonnet
+++ b/catalog/FAO/FAO_WAPOR_3_L1_T_D.jsonnet
@@ -50,7 +50,7 @@ local self_ee_catalog_url = ee_const.ee_catalog_url + basename;
   extent: ee.extent(-30.0044643, -40.0044644, 65.0044644, 40.0044643,
                     '2009-01-01T00:00:00Z', null),
   summaries: {
-    gsd: [248.2],
+    gsd: [326.13],
     'eo:bands': [
       {
         name: 'L1-T-D',


### PR DESCRIPTION
The gsd for the FAO/WAPOR/3/L1_{AETI,E,I,T}_D collections was carried over from the v2 records. WaPOR v3 Level 1 data is on a ~326.13 m grid.